### PR TITLE
Fix for a process name detection.

### DIFF
--- a/NLog.Slack/SlackTarget.cs
+++ b/NLog.Slack/SlackTarget.cs
@@ -103,7 +103,7 @@ namespace NLog.Slack
                         attachment.Fields.Add(new Field("Stack Trace") { Value = "```" + exception.StackTrace + "```" });
                 }
 
-                attachment.Fields.Add(new Field("Process Name") { Value = String.Format("{0}\\{1}", _currentProcess.MachineName, _currentProcess.ProcessName), Short = true });
+                attachment.Fields.Add(new Field("Process Name") { Value = String.Format("{0}\\{1}", (_currentProcess.MachineName != "." ? _currentProcess.MachineName : System.Environment.MachineName), _currentProcess.ProcessName), Short = true });
                 attachment.Fields.Add(new Field("Process PID") { Value = _currentProcess.Id.ToString(), Short = true });
 
                 slack.AddAttachment(attachment);


### PR DESCRIPTION
According to MSDN, when the associated process is executing on the local machine, this property returns a period (".") for the machine name. You should use the Environment.MachineName property to get the correct machine name. (https://msdn.microsoft.com/en-us/library/system.diagnostics.process.machinename(v=vs.110).aspx)