### PR TITLE
Enhance user name and channel to accept variables (SimpleLayout)

### DIFF
--- a/NLog.Slack.Tests/SlackTargetTests.cs
+++ b/NLog.Slack.Tests/SlackTargetTests.cs
@@ -2,6 +2,8 @@
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+using NLog.Layouts;
+
 namespace NLog.Slack.Tests
 {
     [TestClass]
@@ -26,10 +28,10 @@ namespace NLog.Slack.Tests
         [TestMethod]
         public void CustomSettings_ShouldBeCorrect()
         {
-            const string channel = "#log";
+            const string channel = "#log-${level}";
             const bool compact = true;
             const string icon = ":ghost:";
-            const string username = "NLog.Slack";
+            const string username = "NLog.Slack-${level}";
             const string webHookUrl = "http://slack.is.awesome.com";
 
             var slackTarget = new TestableSlackTarget
@@ -41,11 +43,15 @@ namespace NLog.Slack.Tests
                     WebHookUrl = webHookUrl
                 };
 
-            slackTarget.Channel.Should().Be(channel);
+            var logEvent = new LogEventInfo { Level = LogLevel.Info, Message = "This is a ${level} message" };
+
+            slackTarget.Channel.Render(logEvent).Should().Be("#log-Info");
+            slackTarget.Username.Render(logEvent).Should().Be("NLog.Slack-Info");
             slackTarget.Compact.Should().Be(compact);
             slackTarget.Icon.Should().Be(icon);
-            slackTarget.Username.Should().Be(username);
             slackTarget.WebHookUrl.Should().Be(webHookUrl);
+
+            
         }
 
         //// ----------------------------------------------------------------------------------------------------------

--- a/NLog.Slack.Tests/SlackTargetTests.cs
+++ b/NLog.Slack.Tests/SlackTargetTests.cs
@@ -91,6 +91,30 @@ namespace NLog.Slack.Tests
             slackTarget.Initialize();
         }
 
+        [TestMethod, ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void InitializeTarget_IncorrectChannel_ExtraCharWithAt_ShouldThrowException()
+        {
+            var slackTarget = new TestableSlackTarget
+            {
+                WebHookUrl = "http://slack.is.awesome.com",
+                Channel = "w@slackbot"
+            };
+
+            slackTarget.Initialize();
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void InitializeTarget_IncorrectChannel_ExtraCharWithHash_ShouldThrowException()
+        {
+            var slackTarget = new TestableSlackTarget
+            {
+                WebHookUrl = "http://slack.is.awesome.com",
+                Channel = "w#log"
+            };
+
+            slackTarget.Initialize();
+        }
+
         //// ----------------------------------------------------------------------------------------------------------
 
         [TestMethod]
@@ -109,6 +133,20 @@ namespace NLog.Slack.Tests
 
         [TestMethod]
         public void InitializeTarget_CorrectChannelWithAt_TargetShouldInitialize()
+        {
+            var slackTarget = new TestableSlackTarget
+            {
+                WebHookUrl = "http://slack.is.awesome.com",
+                Channel = "@slackbot"
+            };
+
+            slackTarget.Initialize();
+        }
+
+        //// ----------------------------------------------------------------------------------------------------------
+        
+        [TestMethod]
+        public void InitializeTarget_CorrectChannelWithVariable_TargetShouldInitialize()
         {
             var slackTarget = new TestableSlackTarget
             {

--- a/NLog.Slack/SlackTarget.cs
+++ b/NLog.Slack/SlackTarget.cs
@@ -23,11 +23,11 @@ namespace NLog.Slack
 
         //// ----------------------------------------------------------------------------------------------------------
 
-        public string Channel { get; set; }
+        public Layout Channel { get; set; }
 
         //// ----------------------------------------------------------------------------------------------------------
 
-        public string Username { get; set; }
+        public Layout Username { get; set; }
 
         //// ----------------------------------------------------------------------------------------------------------
 
@@ -48,8 +48,8 @@ namespace NLog.Slack
             if (!Uri.TryCreate(this.WebHookUrl, UriKind.Absolute, out uriResult))
                 throw new ArgumentOutOfRangeException("WebHookUrl", "Webhook URL is an invalid URL.");
 
-            if (!String.IsNullOrWhiteSpace(this.Channel)
-                && !"@#".Any(this.Channel.Contains))
+            if (!String.IsNullOrWhiteSpace(this.Channel.ToString())
+                && !"@#".Any(this.Channel.ToString().Contains))
                 throw new ArgumentOutOfRangeException("Channel", "The Channel name is invalid. It must start with either a # or a @ symbol.");
 
             base.InitializeTarget();
@@ -79,14 +79,14 @@ namespace NLog.Slack
                 .OnError(e => info.Continuation(e))
                 .WithMessage(message);
 
-            if (!String.IsNullOrWhiteSpace(this.Channel))
-                slack.ToChannel(this.Channel);
+            if (!String.IsNullOrWhiteSpace(this.Channel.Render(info.LogEvent)))
+                slack.ToChannel(this.Channel.Render(info.LogEvent));
 
             if (!String.IsNullOrWhiteSpace(this.Icon))
                 slack.WithIcon(this.Icon);
 
-            if (!String.IsNullOrWhiteSpace(this.Username))
-                slack.AsUser(this.Username);
+            if (!String.IsNullOrWhiteSpace(this.Username.Render(info.LogEvent)))
+                slack.AsUser(this.Username.Render(info.LogEvent));
 
             if (!this.Compact)
             {

--- a/NLog.Slack/SlackTarget.cs
+++ b/NLog.Slack/SlackTarget.cs
@@ -23,11 +23,11 @@ namespace NLog.Slack
 
         //// ----------------------------------------------------------------------------------------------------------
 
-        public Layout Channel { get; set; }
+        public SimpleLayout Channel { get; set; }
 
         //// ----------------------------------------------------------------------------------------------------------
 
-        public Layout Username { get; set; }
+        public SimpleLayout Username { get; set; }
 
         //// ----------------------------------------------------------------------------------------------------------
 
@@ -48,9 +48,9 @@ namespace NLog.Slack
             if (!Uri.TryCreate(this.WebHookUrl, UriKind.Absolute, out uriResult))
                 throw new ArgumentOutOfRangeException("WebHookUrl", "Webhook URL is an invalid URL.");
 
-            if (!String.IsNullOrWhiteSpace(this.Channel.ToString())
-                && !"@#".Any(this.Channel.ToString().Contains))
-                throw new ArgumentOutOfRangeException("Channel", "The Channel name is invalid. It must start with either a # or a @ symbol.");
+            if (!String.IsNullOrWhiteSpace(this.Channel.Text)
+                && (!this.Channel.Text.StartsWith("#") && !this.Channel.Text.StartsWith("@") && !this.Channel.Text.StartsWith("${")))
+                throw new ArgumentOutOfRangeException("Channel", "The Channel name is invalid. It must start with either a # or a @ symbol or use a variable.");
 
             base.InitializeTarget();
         }


### PR DESCRIPTION
This allows for the use of variables within the configuration so that
the messages can be routed based on the config dynamically without needing to code that behaviour.

This is inspired by the File target which lets you for example write to multiple files with a single target.
I wanted to be able to write to multiple channels (or have messages appear from multiple "users") with the same target.