### PR TITLE
Expandable StackTrace

### DIFF
--- a/NLog.Slack.Demo/Program.cs
+++ b/NLog.Slack.Demo/Program.cs
@@ -18,7 +18,7 @@ namespace NLog.Slack.Demo
 
             try
             {
-                throw new ApplicationException("I'm the exception to the rule.");
+                CreateBigStackTrace(20);
             }
             catch (Exception ex)
             {
@@ -27,6 +27,20 @@ namespace NLog.Slack.Demo
 
             Console.WriteLine("Done - check your Slack channel!");
             Console.ReadLine();
+        }
+
+        //// ----------------------------------------------------------------------------------------------------------
+
+        private static void CreateBigStackTrace(int lines)
+        {
+            if (lines < 1)
+            {
+                throw new ApplicationException("I'm the exception to the rule.");
+            }
+            else
+            {
+                CreateBigStackTrace(lines - 1);
+            }
         }
 
         //// ----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Add a new attachement when there is an Exception.
The stack trace become the text part of the attachment so we can have an expandable link in Slack.
Update the demo to demonstrate the effect.
I think it is good to not have the full stacktrace on Slack, just the 4 first lines (default in Slack), and then expand if necessary.
I have not update the Readme, but I will if you agree with the PR