### PR TITLE
Remove Newtonsoft.Json dependency

### DIFF
--- a/NLog.Slack/Models/Payload.cs
+++ b/NLog.Slack/Models/Payload.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
 
 namespace NLog.Slack.Models
 {
@@ -41,6 +43,23 @@ namespace NLog.Slack.Models
         public Payload()
         {
             this.Attachments = new List<Attachment>();
+        }
+
+        //// ----------------------------------------------------------------------------------------------------------
+
+        public string ToJson()
+        {
+            var serializer = new DataContractJsonSerializer(typeof(Payload));
+            using (var memoryStream = new MemoryStream())
+            {
+                serializer.WriteObject(memoryStream, this);
+                memoryStream.Position = 0;
+                using (var reader = new StreamReader(memoryStream))
+                {
+                    string json = reader.ReadToEnd();
+                    return json;
+                }
+            }
         }
 
         //// ----------------------------------------------------------------------------------------------------------

--- a/NLog.Slack/NLog.Slack.csproj
+++ b/NLog.Slack/NLog.Slack.csproj
@@ -30,10 +30,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="NLog">
       <HintPath>..\packages\NLog.3.1.0.0\lib\net45\NLog.dll</HintPath>
     </Reference>

--- a/NLog.Slack/SlackMessageBuilder.cs
+++ b/NLog.Slack/SlackMessageBuilder.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-
-using Newtonsoft.Json;
-
 using NLog.Slack.Models;
 
 namespace NLog.Slack
@@ -104,7 +101,7 @@ namespace NLog.Slack
 
         public void Send()
         {
-            this._client.Send(this._webHookUrl, JsonConvert.SerializeObject(_payload));
+            this._client.Send(this._webHookUrl, this._payload.ToJson());
         }
 
         //// ----------------------------------------------------------------------------------------------------------

--- a/NLog.Slack/packages.config
+++ b/NLog.Slack/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NLog" version="3.1.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I think this is non consensual, because newtonsoft.json had the best performance for serialization (2 time faster that DataContractJsonSerializer : http://www.newtonsoft.com/content/images/jsonperformance.png)

But performance of serialization is irrevelant in the case of sending data to slack, this is not something you want to do in a loop.

And I'm ready to trade 300ms against a more lightweight library.