### PR TITLE
Fixes various bugs

### DIFF
--- a/NLog.Slack.Tests/SlackTargetTests.cs
+++ b/NLog.Slack.Tests/SlackTargetTests.cs
@@ -72,7 +72,7 @@ namespace NLog.Slack.Tests
             var slackTarget = new TestableSlackTarget
                 {
                     WebHookUrl = "IM A BIG FAT PHONY"
-            };
+                };
 
             slackTarget.Initialize();
         }

--- a/NLog.Slack.Tests/SlackTargetTests.cs
+++ b/NLog.Slack.Tests/SlackTargetTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -72,7 +72,7 @@ namespace NLog.Slack.Tests
             var slackTarget = new TestableSlackTarget
                 {
                     WebHookUrl = "IM A BIG FAT PHONY"
-                };
+            };
 
             slackTarget.Initialize();
         }
@@ -152,6 +152,34 @@ namespace NLog.Slack.Tests
             {
                 WebHookUrl = "http://slack.is.awesome.com",
                 Channel = "@slackbot"
+            };
+
+            slackTarget.Initialize();
+        }
+
+        //// ----------------------------------------------------------------------------------------------------------
+
+        [TestMethod]
+        public void InitializeTarget_NoChannel_TargetShouldInitialize()
+        {
+            var slackTarget = new TestableSlackTarget
+            {
+                WebHookUrl = "http://slack.is.awesome.com",
+                Channel    = null,
+            };
+
+            slackTarget.Initialize();
+        }
+
+        //// ----------------------------------------------------------------------------------------------------------
+        
+        [TestMethod]
+        public void InitializeTarget_NoUsername_TargetShouldInitialize()
+        {
+            var slackTarget = new TestableSlackTarget
+            {
+                WebHookUrl = "http://slack.is.awesome.com",
+                Username    = null,
             };
 
             slackTarget.Initialize();

--- a/NLog.Slack/SlackTarget.cs
+++ b/NLog.Slack/SlackTarget.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using NLog.Common;
 using NLog.Config;
@@ -51,7 +51,7 @@ namespace NLog.Slack
             if (!Uri.TryCreate(this.WebHookUrl, UriKind.Absolute, out uriResult))
                 throw new ArgumentOutOfRangeException("WebHookUrl", "Webhook URL is an invalid URL.");
 
-            if (!String.IsNullOrWhiteSpace(this.Channel.Text)
+            if (!String.IsNullOrWhiteSpace(this.Channel?.Text)
                 && (!this.Channel.Text.StartsWith("#") && !this.Channel.Text.StartsWith("@") && !this.Channel.Text.StartsWith("${")))
                 throw new ArgumentOutOfRangeException("Channel", "The Channel name is invalid. It must start with either a # or a @ symbol or use a variable.");
 
@@ -89,15 +89,15 @@ namespace NLog.Slack
                 .OnError(e => info.Continuation(e))
                 .WithMessage(message);
 
-            var channelValue = this.Channel.Render(info.LogEvent);
+            var channelValue = this.Channel?.Render(info.LogEvent);
             if (!String.IsNullOrWhiteSpace(channelValue))
                 slack.ToChannel(channelValue);
 
-            var iconValue = this.Channel.Render(info.LogEvent);
+            var iconValue = this.Icon;
             if (!String.IsNullOrWhiteSpace(iconValue))
                 slack.WithIcon(iconValue);
 
-            var usernameValue = this.Username.Render(info.LogEvent);
+            var usernameValue = this.Username?.Render(info.LogEvent);
             if (!String.IsNullOrWhiteSpace(usernameValue))
                 slack.AsUser(usernameValue);
 


### PR DESCRIPTION
I was frustrated due to the issues I mentioned in #16, so I decided to fork it and see if I could find out why my config wasn't working. I was able to identify and fix several bugs:

- Not specifying the channel in the `NLog.config` would cause a `NullReferenceException` in `SlackTarget.InitializeTarget`
- The same problem would cause an issue in `SlackTarget.SendToSlack`
- The same issue would happen in `SlackTarget.SendToSlack` if the username field wasn't set
- The icon value was being given the same value as the `Channel` property

I also added some tests to verify that it works.